### PR TITLE
Update API.scala

### DIFF
--- a/piflow-server/src/main/scala/cn/piflow/api/API.scala
+++ b/piflow-server/src/main/scala/cn/piflow/api/API.scala
@@ -138,24 +138,23 @@ object API {
       val matricInfo = MapUtil.get(yarnInfo, "clusterMetrics").asInstanceOf[Map[String, Any]]
 
 
-      val totalVirtualCores = matricInfo.getOrElse("totalVirtualCores","");
-      val allocatedVirtualCores = matricInfo.getOrElse("allocatedVirtualCores","")
-      val remainingVirtualCores = totalVirtualCores.toString.toDouble - allocatedVirtualCores.toString.toDouble;
+      val totalVirtualCores = matricInfo.getOrElse("totalVirtualCores","").toString
+      val allocatedVirtualCores = matricInfo.getOrElse("allocatedVirtualCores","").toString
+      val remainingVirtualCores = totalVirtualCores.toDouble - allocatedVirtualCores.toDouble
       val cpuInfo = Map(
         "totalVirtualCores" -> totalVirtualCores,
         "allocatedVirtualCores" -> allocatedVirtualCores,
         "remainingVirtualCores" -> remainingVirtualCores
       )
 
-      val totalMemoryGB = matricInfo.getOrElse("totalMB","").toString.toDouble/1024;
-      val allocatedMemoryGB = matricInfo.getOrElse("allocatedMB","").toString.toDouble/1024;
-      val remainingMemoryGB =  totalMemoryGB - allocatedMemoryGB;
+      val totalMemoryGB = matricInfo.getOrElse("totalMB","").toString.toDouble/1024
+      val allocatedMemoryGB = matricInfo.getOrElse("allocatedMB","").toString.toDouble/1024
+      val remainingMemoryGB =  totalMemoryGB - allocatedMemoryGB
       val memoryInfo = Map(
         "totalMemoryGB" -> totalMemoryGB,
         "allocatedMemoryGB" -> allocatedMemoryGB,
         "remainingMemoryGB" -> remainingMemoryGB
       )
-
       val hdfsInfo = HdfsUtil.getCapacity()
       val map = Map("cpu" -> cpuInfo, "memory" -> memoryInfo, "hdfs" -> hdfsInfo)
       val resultMap = Map("resource" -> map)


### PR DESCRIPTION
您好，
原代码中，matricInfo.getOrElse("totalVirtualCores","")返回的为Integer类型，下一步使用.asInstanceOf[Double]是不安全的，因为 Integer 和 Double 之间没有直接的继承关系，会报错：java.lang.Integer cannot be cast to java.lang.Double

修改代码将原返回值转换为字符串，之后使用toDouble方法进行转换。

另，去掉部分scala代码中结尾的不必要分号